### PR TITLE
Fix custom ec2 tags

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -70,7 +70,7 @@ export class ActionConfig implements ConfigInterface {
         this.ec2InstanceType = core.getInput("ec2_instance_type");
         this.ec2AmiId = core.getInput("ec2_ami_id");
         this.ec2InstanceIamRole = core.getInput("ec2_instance_iam_role");
-        this.ec2InstanceTags = JSON.parse(core.getInput("ec2_instance_tags"));
+        this.ec2InstanceTags = core.getInput("ec2_instance_tags");
         this.ec2InstanceTtl = core.getInput("ec2_instance_ttl");
         this.ec2SubnetId = core.getInput("ec2_subnet_id");
         this.ec2SecurityGroupId = core.getInput("ec2_security_group_id");

--- a/src/ec2/ec2.ts
+++ b/src/ec2/ec2.ts
@@ -55,6 +55,12 @@ export class Ec2Instance {
   }
 
   getTags() {
+    // Parse custom tags
+    let customTags = []
+    if(this.config.ec2InstanceTags){
+      customTags = JSON.parse(this.config.ec2InstanceTags);
+    }
+
     return [
       {
         Key: "Name",
@@ -75,13 +81,8 @@ export class Ec2Instance {
       {
         Key: "github_repo",
         Value: this.config.githubRepo,
-      }
-      /*
-            {
-                Key: "expiration",
-                Value: "some time goes here"
-            },
-            */
+      },
+        ...customTags
     ];
   }
 


### PR DESCRIPTION
Custom tags were not being consumed. This PR ensures user provided tags as part of Action configurations are injected into EC2 creation request. 

This change has been tested and verified. 