### PR TITLE
Adding configurable retry interval for runner polling job

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,10 @@ inputs:
     description: 'Maximum duration a runner instance is allowed to be idle before a job is started in seconds'
     required: false
     default: '0'
+  github_api_retry_delay:
+    description: 'Retry delay between calls to github APIs'
+    required: false
+    default: '10'
   ec2_instance_type:
     description: 'Ec2 instance type'
     required: true

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,6 +17,7 @@ export interface ConfigInterface {
   githubActionRunnerExtraCliArgs: string;
   githubActionRunnerLabel: string;
   githubJobStartTtlSeconds: string;
+  githubApiRetryDelay: number;
 
   ec2InstanceType: string;
   ec2AmiId: string;
@@ -47,6 +48,7 @@ export class ActionConfig implements ConfigInterface {
   githubActionRunnerExtraCliArgs: string;
   githubActionRunnerLabel: string;
   githubJobStartTtlSeconds: string;
+  githubApiRetryDelay: number;
 
   ec2InstanceType: string;
   ec2AmiId: string;
@@ -82,6 +84,8 @@ export class ActionConfig implements ConfigInterface {
     );
     this.githubActionRunnerLabel = this.githubJobId;
     this.githubJobStartTtlSeconds = core.getInput("github_job_start_ttl_seconds");
+    this.githubApiRetryDelay = parseInt(core.getInput("github_api_retry_delay"), 10) || 10;
+
 
     // Ec2 params
     this.ec2InstanceType = core.getInput("ec2_instance_type");

--- a/src/ec2/ec2.ts
+++ b/src/ec2/ec2.ts
@@ -283,7 +283,9 @@ export class Ec2Instance {
 
     var params: RunInstancesCommandInput = {
       ImageId: this.config.ec2AmiId,
-      IamInstanceProfile: this.config.ec2IamInstanceProfile ? this.config.ec2IamInstanceProfile : undefined,
+      IamInstanceProfile: this.config.ec2IamInstanceProfile
+          ? { Name: this.config.ec2IamInstanceProfile } // Assuming ec2IamInstanceProfile is a name, not an ARN
+          : undefined,
       InstanceInitiatedShutdownBehavior: "terminate",
       InstanceMarketOptions: {},
       InstanceType: this.config.ec2InstanceType as _InstanceType,


### PR DESCRIPTION
- Fix a loop potentially causing Github API rate limiting when polling for instance registration
- Added `github_api_retry_delay` to control the polling interval